### PR TITLE
Fix header titles displaying routes instead of screen names

### DIFF
--- a/app/(app)/exercises/grammar/[exercise_id].tsx
+++ b/app/(app)/exercises/grammar/[exercise_id].tsx
@@ -18,9 +18,9 @@ import {
   ButtonIcon,
   Spinner,
 } from "tamagui";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { Alert, useColorScheme } from "react-native";
-import { useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams, useNavigation } from "expo-router";
 import { ExerciseService } from "../../../../src/services/ExerciseService";
 import { GrammarExercise } from "../../../../src/models/GrammarExercise";
 import { GrammarExerciseUI } from "../../../../src/components/ExerciseUI";
@@ -45,12 +45,19 @@ export default function GrammarExercises({
   const [loadingText, setLoadingText] = useState("Loading...");
   const [exercise, setExercise] = useState<GrammarExercise | null>();
   const [exerciseLevel, setExerciseLevel] = useState(0);
+  const navigation = useNavigation();
 
   const { getUserUUID } = useSession();
 
   useEffect(() => {
     loadExercise();
   }, []);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerShown: false,
+    });
+  }, [navigation]);
 
   const loadExercise = async () => {
     try {

--- a/app/(app)/exercises/grammar/[exercise_id]/edit.tsx
+++ b/app/(app)/exercises/grammar/[exercise_id]/edit.tsx
@@ -13,9 +13,9 @@ import {
   ScrollView,
   Separator,
 } from "tamagui";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { useColorScheme } from "react-native";
-import { Link, useLocalSearchParams } from "expo-router";
+import { Link, useLocalSearchParams, useNavigation } from "expo-router";
 import { ExerciseService } from "../../../../../src/services/ExerciseService";
 import { VocabularyExercise } from "../../../../../src/models/VocabularyExercise";
 import { ExerciseTypes } from "../../../../../src/utils/enums";
@@ -47,6 +47,7 @@ export default function EditGrammarExercise({ session }: { session: Session }) {
   });
   const [disabled, setDisabled] = useState(true);
   const [saved, setSaved] = useState(false);
+  const navigation = useNavigation();
 
   useEffect(() => {
     if (
@@ -57,6 +58,12 @@ export default function EditGrammarExercise({ session }: { session: Session }) {
       setDisabled(false);
     }
   }, [exercise]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: "Edit Grammar Exercise"
+    });
+  }, [navigation]);
 
   const displayDetails = async () => {
     let exercise_details = await ExerciseService.getGrammarExerciseProblems(

--- a/app/(app)/exercises/grammar/create.tsx
+++ b/app/(app)/exercises/grammar/create.tsx
@@ -14,9 +14,9 @@ import {
   Progress,
   ScrollView,
 } from "tamagui";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { useColorScheme } from "react-native";
-import { Link, useLocalSearchParams } from "expo-router";
+import { Link, useLocalSearchParams, useNavigation } from "expo-router";
 import { ExerciseService } from "../../../../src/services/ExerciseService";
 import { VocabularyExercise } from "../../../../src/models/VocabularyExercise";
 import { ExerciseTypes } from "../../../../src/utils/enums";
@@ -51,6 +51,7 @@ export default function CreateGrammarExercise({
   });
   const [disabled, setDisabled] = useState(true);
   const [saved, setSaved] = useState(false);
+  const navigation = useNavigation();
 
   useEffect(() => {
     if (
@@ -61,6 +62,12 @@ export default function CreateGrammarExercise({
       setDisabled(false);
     }
   }, [exercise]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: "Create Grammar Exercise"
+    });
+  }, [navigation]);
 
   const save = async () => {
     setDisabled(true);

--- a/app/(app)/exercises/listening/[exercise_id].tsx
+++ b/app/(app)/exercises/listening/[exercise_id].tsx
@@ -18,9 +18,9 @@ import {
   ButtonIcon,
   Spinner,
 } from "tamagui";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { Alert, useColorScheme } from "react-native";
-import { useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams, useNavigation } from "expo-router";
 import { ExerciseService } from "../../../../src/services/ExerciseService";
 import { ListeningExercise } from "../../../../src/models/ListeningExercise";
 import { ListeningExerciseUI } from "../../../../src/components/ExerciseUI";
@@ -45,12 +45,19 @@ export default function ListeningExercises({
   const [loadingText, setLoadingText] = useState("Loading...");
   const [exercise, setExercise] = useState<ListeningExercise | null>();
   const [exerciseLevel, setExerciseLevel] = useState(0);
+  const navigation = useNavigation();
 
   const { getUserUUID } = useSession();
 
   useEffect(() => {
     loadExercise();
   }, []);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerShown: false,
+    });
+  }, [navigation]);
 
   const loadExercise = async () => {
     try {

--- a/app/(app)/exercises/listening/[exercise_id]/edit.tsx
+++ b/app/(app)/exercises/listening/[exercise_id]/edit.tsx
@@ -13,9 +13,9 @@ import {
   ScrollView,
   Separator,
 } from "tamagui";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { useColorScheme } from "react-native";
-import { Link, useLocalSearchParams } from "expo-router";
+import { Link, useLocalSearchParams, useNavigation } from "expo-router";
 import { ExerciseService } from "../../../../../src/services/ExerciseService";
 import { VocabularyExercise } from "../../../../../src/models/VocabularyExercise";
 import { ExerciseTypes } from "../../../../../src/utils/enums";
@@ -53,6 +53,7 @@ export default function EditListeningExercise({
   });
   const [disabled, setDisabled] = useState(true);
   const [saved, setSaved] = useState(false);
+  const navigation = useNavigation();
 
   useEffect(() => {
     if (
@@ -63,6 +64,12 @@ export default function EditListeningExercise({
       setDisabled(false);
     }
   }, [exercise]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: "Edit Listening Exercise"
+    });
+  }, [navigation]);
 
   const displayDetails = async () => {
     let exercise_details = await ExerciseService.getListeningExerciseProblems(

--- a/app/(app)/exercises/listening/create.tsx
+++ b/app/(app)/exercises/listening/create.tsx
@@ -14,9 +14,9 @@ import {
   Progress,
   ScrollView,
 } from "tamagui";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { useColorScheme } from "react-native";
-import { Link, useLocalSearchParams } from "expo-router";
+import { Link, useLocalSearchParams, useNavigation } from "expo-router";
 import { ExerciseService } from "../../../../src/services/ExerciseService";
 import { VocabularyExercise } from "../../../../src/models/VocabularyExercise";
 import { ExerciseTypes } from "../../../../src/utils/enums";
@@ -51,6 +51,7 @@ export default function CreateListeningExercise({
   });
   const [disabled, setDisabled] = useState(true);
   const [saved, setSaved] = useState(false);
+  const navigation = useNavigation();
 
   useEffect(() => {
     if (
@@ -61,6 +62,12 @@ export default function CreateListeningExercise({
       setDisabled(false);
     }
   }, [exercise]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: "Create Listening Exercise"
+    });
+  }, [navigation]);
 
   const save = async () => {
     setDisabled(true);

--- a/app/(app)/exercises/vocabulary/[exercise_id].tsx
+++ b/app/(app)/exercises/vocabulary/[exercise_id].tsx
@@ -18,9 +18,9 @@ import {
   ButtonIcon,
   Spinner,
 } from "tamagui";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { Alert, useColorScheme } from "react-native";
-import { useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams, useNavigation } from "expo-router";
 import { ExerciseService } from "../../../../src/services/ExerciseService";
 import { VocabularyExercise } from "../../../../src/models/VocabularyExercise";
 import { VocabularyExerciseUI } from "../../../../src/components/ExerciseUI";
@@ -45,12 +45,19 @@ export default function VocabularyExercises({
   const [loadingText, setLoadingText] = useState("Loading...");
   const [exercise, setExercise] = useState<VocabularyExercise | null>();
   const [exerciseLevel, setExerciseLevel] = useState(0);
+  const navigation = useNavigation();
 
   const { getUserUUID } = useSession();
 
   useEffect(() => {
     loadExercise();
   }, []);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerShown: false, // Hides the header for this screen
+    });
+  }, [navigation]);
 
   const loadExercise = async () => {
     try {

--- a/app/(app)/exercises/vocabulary/[exercise_id]/edit.tsx
+++ b/app/(app)/exercises/vocabulary/[exercise_id]/edit.tsx
@@ -11,9 +11,9 @@ import {
   Label,
   Input,
 } from "tamagui";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { useColorScheme } from "react-native";
-import { Link, useLocalSearchParams } from "expo-router";
+import { Link, useLocalSearchParams, useNavigation } from "expo-router";
 import { ExerciseService } from "../../../../../src/services/ExerciseService";
 import { VocabularyExercise } from "../../../../../src/models/VocabularyExercise";
 import { ExerciseTypes } from "../../../../../src/utils/enums";
@@ -49,6 +49,7 @@ export default function EditVocabularyExercise({
   });
   const [disabled, setDisabled] = useState(true);
   const [saved, setSaved] = useState(false);
+  const navigation = useNavigation();
 
   useEffect(() => {
     if (
@@ -59,6 +60,12 @@ export default function EditVocabularyExercise({
       setDisabled(false);
     }
   }, [exercise]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: "Edit Vocabulary Exercise"
+    });
+  }, [navigation]);
 
   const displayDetails = async () => {
     let exercise_details = await ExerciseService.getVocabularyExerciseProblems(

--- a/app/(app)/exercises/vocabulary/create.tsx
+++ b/app/(app)/exercises/vocabulary/create.tsx
@@ -11,9 +11,9 @@ import {
   Label,
   Input,
 } from "tamagui";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { useColorScheme } from "react-native";
-import { Link, useLocalSearchParams } from "expo-router";
+import { Link, useLocalSearchParams, useNavigation } from "expo-router";
 import { ExerciseService } from "../../../../src/services/ExerciseService";
 import { VocabularyExercise } from "../../../../src/models/VocabularyExercise";
 import { ExerciseTypes } from "../../../../src/utils/enums";
@@ -46,6 +46,7 @@ export default function CreateVocabularyExercise({
   });
   const [disabled, setDisabled] = useState(true);
   const [saved, setSaved] = useState(false);
+  const navigation = useNavigation();
 
   useEffect(() => {
     if (
@@ -56,6 +57,12 @@ export default function CreateVocabularyExercise({
       setDisabled(false);
     }
   }, [exercise]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: "Create Vocabulary Exercise"
+    });
+  }, [navigation]);
 
   const save = async () => {
     setDisabled(true);


### PR DESCRIPTION
Adjusted individual screens to just outright not show header titles while some screens had their header titles defined (as it was previously neglected before).